### PR TITLE
Add deleteMetadata method to Document.

### DIFF
--- a/src/Document/Document.php
+++ b/src/Document/Document.php
@@ -67,6 +67,14 @@ class Document implements DocumentInterface {
   /**
    * {@inheritdoc}
    */
+  public function deleteMetadata($name) {
+    unset($this->document->{$name});
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getCurrentLanguageFieldsValues() {
     $result = new \stdClass();
     foreach ($this->getFieldMachineNames() as $field_name) {

--- a/src/Document/DocumentInterface.php
+++ b/src/Document/DocumentInterface.php
@@ -154,4 +154,15 @@ interface DocumentInterface {
    */
   public function getCurrentLanguage();
 
+  /**
+   * Delete metadata.
+   *
+   * @param string $name
+   *    Metadata name.
+   *
+   * @return DocumentInterface
+   *    Delete metadata and return document object.
+   */
+  public function deleteMetadata($name);
+
 }


### PR DESCRIPTION
Deleting a metadata (e.g. id) from the document before encoding it would be useful: for instance while encoding to JSON the returned value is raw string, which is less easy to manipulate.
